### PR TITLE
FIDEFE-4687 - Refactor generated media query placement within file

### DIFF
--- a/toolkit/themes/shared/design-system/build/css/tokens-shared.css
+++ b/toolkit/themes/shared/design-system/build/css/tokens-shared.css
@@ -49,10 +49,8 @@
   --color-background-success: light-dark(var(--color-green-05), var(--color-yellow-80));
   --color-background-information: light-dark(var(--color-blue-05), var(--color-blue-80));
   --color-background-critical: light-dark(var(--color-red-05), var(--color-red-80));
-}
 
-@media (prefers-contrast) {
-  :root {
+  @media (prefers-contrast) {
     --text-color-deemphasized: inherit;
     --text-color-default: CanvasText;
     --border-interactive-color-disabled: GrayText;
@@ -61,10 +59,8 @@
     --border-interactive-color-default: AccentColor;
     --border-color: var(--text-color-default);
   }
-}
 
-@media (forced-colors) {
-  :root {
+  @media (forced-colors) {
     --border-interactive-color-disabled: GrayText;
     --border-interactive-color-active: ButtonText;
     --border-interactive-color-hover: ButtonText;

--- a/toolkit/themes/shared/design-system/config.js
+++ b/toolkit/themes/shared/design-system/config.js
@@ -50,9 +50,11 @@ const MEDIA_QUERY_PROPERTY_MAP = {
 function hcmFormatter(args) {
   return (
     customFileHeader() +
+    ":root {\n" +
     formatTokens({ args }) +
     formatTokens({ mediaQuery: "prefers-contrast", args }) +
-    formatTokens({ mediaQuery: "forced-colors", args })
+    formatTokens({ mediaQuery: "forced-colors", args }) +
+    "}\n"
   ).replaceAll(/(?<tokenName>\w+)-base(?=\b)/g, "$<tokenName>");
 }
 
@@ -96,15 +98,13 @@ function formatTokens({ mediaQuery, args }) {
   // Weird spacing below is unfortunately necessary formatting the built CSS.
   if (mediaQuery) {
     return `
-@media (${mediaQuery}) {
-  :root {
+  @media (${mediaQuery}) {
 ${formattedVars}
   }
-}
 `;
   }
-
-  return `:root {\n${formattedVars}\n}\n`;
+  return formattedVars + "\n";
+  
 }
 
 /**


### PR DESCRIPTION
According to a11y's recommendation, https://firefox-source-docs.mozilla.org/accessible/HCMMediaQueries.html#writing-maintainable-frontend-code, we should move the generated media queries within the :root block.

In order to get the tests to pass, I also needed to pull the test changes from FirefoxUX#8. I did not pull any other changes from that PR.