### PR TITLE
RECOMP-226 - Generate CSS layer declarations and relevant selectors.

### DIFF
--- a/toolkit/themes/shared/design-system/build/css/tokens-brand.css
+++ b/toolkit/themes/shared/design-system/build/css/tokens-brand.css
@@ -11,13 +11,15 @@
 
 @import url("chrome://global/skin/design-system/tokens-shared.css");
 
-:root,
-:host(.anonymous-content-host) {
-  /* Application tokens */
-  /** Border **/
-  --border-interactive-color: light-dark(var(--color-gray-60), var(--color-gray-50));
+@layer tokens-foundation {
+  :root,
+  :host(.anonymous-content-host) {
+    /* Application tokens */
+    /** Border **/
+    --border-interactive-color: light-dark(var(--color-gray-60), var(--color-gray-50));
 
-  /** Text **/
-  --text-color: light-dark(var(--color-gray-100), var(--color-gray-05));
-  --text-color-deemphasized: light-dark(color-mix(in srgb, currentColor 69%, transparent), color-mix(in srgb, currentColor 75%, transparent));
+    /** Text **/
+    --text-color: light-dark(var(--color-gray-100), var(--color-gray-05));
+    --text-color-deemphasized: light-dark(color-mix(in srgb, currentColor 69%, transparent), color-mix(in srgb, currentColor 75%, transparent));
+  }
 }

--- a/toolkit/themes/shared/design-system/build/css/tokens-platform.css
+++ b/toolkit/themes/shared/design-system/build/css/tokens-platform.css
@@ -11,12 +11,14 @@
 
 @import url("chrome://global/skin/design-system/tokens-shared.css");
 
-:root,
-:host(.anonymous-content-host) {
-  /* Application tokens */
-  /** Border **/
-  --border-interactive-color: color-mix(in srgb, currentColor 15%, var(--color-gray-60));
+@layer tokens-foundation {
+  :root,
+  :host(.anonymous-content-host) {
+    /* Application tokens */
+    /** Border **/
+    --border-interactive-color: color-mix(in srgb, currentColor 15%, var(--color-gray-60));
 
-  /** Text **/
-  --text-color: currentColor;
+    /** Text **/
+    --text-color: currentColor;
+  }
 }

--- a/toolkit/themes/shared/design-system/build/css/tokens-shared.css
+++ b/toolkit/themes/shared/design-system/build/css/tokens-shared.css
@@ -9,77 +9,95 @@
  * and run `npm run build` to see your changes.
  */
 
-:root,
-:host(.anonymous-content-host) {
-  /* Base tokens */
-  /** Color **/
-  --color-black-a10: rgba(0, 0, 0, 0.1);
-  --color-blue-05: #deeafc;
-  --color-blue-30: #73a7f3;
-  --color-blue-50: #0060df;
-  --color-blue-60: #0250bb;
-  --color-blue-70: #054096;
-  --color-blue-80: #003070;
-  --color-cyan-20: #aaf2ff;
-  --color-cyan-30: #aaf2ff;
-  --color-cyan-50: #00ddff;
-  --color-gray-05: #fbfbfe;
-  --color-gray-50: #bfbfc9;
-  --color-gray-60: #8f8f9d;
-  --color-gray-70: #5b5b66;
-  --color-gray-80: #23222b;
-  --color-gray-90: #1c1b22;
-  --color-gray-100: #15141a;
-  --color-green-05: #d8eedc;
-  --color-green-30: #4dbc87;
-  --color-green-50: #017a40;
-  --color-green-80: #004725;
-  --color-red-05: #ffe8e8;
-  --color-red-30: #f37f98;
-  --color-red-50: #d7264c;
-  --color-red-80: #690f22;
-  --color-white: #ffffff;
-  --color-yellow-05: #ffebcd;
-  --color-yellow-30: #e49c49;
-  --color-yellow-50: #cd411e;
-  --color-yellow-80: #5a3100;
+@layer tokens-foundation, tokens-prefers-contrast, tokens-forced-colors;
 
-  /* Application tokens */
-  /** Border **/
-  --border-radius-circle: 9999px;
-  --border-radius-medium: 8px;
-  --border-radius-small: 4px;
-  --border-width: 1px;
+@layer tokens-foundation {
+  :root,
+  :host(.anonymous-content-host) {
+    /* Base tokens */
+    /** Color **/
+    --color-black-a10: rgba(0, 0, 0, 0.1);
+    --color-blue-05: #deeafc;
+    --color-blue-30: #73a7f3;
+    --color-blue-50: #0060df;
+    --color-blue-60: #0250bb;
+    --color-blue-70: #054096;
+    --color-blue-80: #003070;
+    --color-cyan-20: #aaf2ff;
+    --color-cyan-30: #aaf2ff;
+    --color-cyan-50: #00ddff;
+    --color-gray-05: #fbfbfe;
+    --color-gray-50: #bfbfc9;
+    --color-gray-60: #8f8f9d;
+    --color-gray-70: #5b5b66;
+    --color-gray-80: #23222b;
+    --color-gray-90: #1c1b22;
+    --color-gray-100: #15141a;
+    --color-green-05: #d8eedc;
+    --color-green-30: #4dbc87;
+    --color-green-50: #017a40;
+    --color-green-80: #004725;
+    --color-red-05: #ffe8e8;
+    --color-red-30: #f37f98;
+    --color-red-50: #d7264c;
+    --color-red-80: #690f22;
+    --color-white: #ffffff;
+    --color-yellow-05: #ffebcd;
+    --color-yellow-30: #e49c49;
+    --color-yellow-50: #cd411e;
+    --color-yellow-80: #5a3100;
 
-  /** Color **/
-  --color-background-critical: light-dark(var(--color-red-05), var(--color-red-80));
-  --color-background-information: light-dark(var(--color-blue-05), var(--color-blue-80));
-  --color-background-success: light-dark(var(--color-green-05), var(--color-yellow-80));
-  --color-background-warning: light-dark(var(--color-yellow-05), var(--color-blue-80));
-
-  /** Text **/
-  --text-color-deemphasized: color-mix(in srgb, currentColor 60%, transparent);
-
-  @media (prefers-contrast) {
     /* Application tokens */
     /** Border **/
-    --border-color: var(--text-color);
-    --border-interactive-color: AccentColor;
-    --border-interactive-color-active: AccentColor;
-    --border-interactive-color-disabled: GrayText;
-    --border-interactive-color-hover: SelectedItem;
+    --border-radius-circle: 9999px;
+    --border-radius-medium: 8px;
+    --border-radius-small: 4px;
+    --border-width: 1px;
+
+    /** Color **/
+    --color-background-critical: light-dark(var(--color-red-05), var(--color-red-80));
+    --color-background-information: light-dark(var(--color-blue-05), var(--color-blue-80));
+    --color-background-success: light-dark(var(--color-green-05), var(--color-yellow-80));
+    --color-background-warning: light-dark(var(--color-yellow-05), var(--color-blue-80));
 
     /** Text **/
-    --text-color: CanvasText;
-    --text-color-deemphasized: inherit;
+    --text-color-deemphasized: color-mix(in srgb, currentColor 60%, transparent);
   }
+}
 
+/* Bug 1879900: Can't nest media queries inside of :host, :root selector
+   until Bug 1879349 lands */
+@layer tokens-prefers-contrast {
+  @media (prefers-contrast) {
+    :root,
+    :host(.anonymous-content-host) {
+      /* Application tokens */
+      /** Border **/
+      --border-color: var(--text-color);
+      --border-interactive-color: AccentColor;
+      --border-interactive-color-active: AccentColor;
+      --border-interactive-color-disabled: GrayText;
+      --border-interactive-color-hover: SelectedItem;
+
+      /** Text **/
+      --text-color: CanvasText;
+      --text-color-deemphasized: inherit;
+    }
+  }
+}
+
+/* Bug 1879900: Can't nest media queries inside of :host, :root selector
+   until Bug 1879349 lands */
+@layer tokens-forced-colors {
   @media (forced-colors) {
-    /* Application tokens */
-    /** Border **/
-    --border-interactive-color: ButtonText;
-    --border-interactive-color-active: ButtonText;
-    --border-interactive-color-disabled: GrayText;
-    --border-interactive-color-hover: ButtonText;
+    :root,
+    :host(.anonymous-content-host) {
+      /* Application tokens */
+      /** Border **/
+      --border-interactive-color: ButtonText;
+      --border-interactive-color-active: ButtonText;
+      --border-interactive-color-disabled: GrayText;
+      --border-interactive-color-hover: ButtonText;
+    }
   }
 }


### PR DESCRIPTION
This brings our Style Dictionary CSS generator in line with our current CSS tokens files.

I had to rewrite the createDesktopFormat and formatTokens to get the formatting of the CSS string correct. I'm happy to refactor into something more understandable, figured it would be worth to get a patch up first though.